### PR TITLE
Allow this to be actually used in Carthage.

### DIFF
--- a/PasswordTextField.xcodeproj/project.pbxproj
+++ b/PasswordTextField.xcodeproj/project.pbxproj
@@ -37,7 +37,6 @@
 		83CBDC5B1C6B07B5006189C2 /* PasswordTextFieldDemoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CBDC5A1C6B07B5006189C2 /* PasswordTextFieldDemoTests.swift */; };
 		83CBDC661C6B07B5006189C2 /* PasswordTextFieldDemoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CBDC651C6B07B5006189C2 /* PasswordTextFieldDemoUITests.swift */; };
 		83CBDC721C6B07C9006189C2 /* PasswordTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83CBDC711C6B07C9006189C2 /* PasswordTextField.swift */; };
-		86CBF3239FCBACA3C421DF4A /* Pods_PasswordTextField.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34E05EFDA6B8A6B9ABAB6F3F /* Pods_PasswordTextField.framework */; };
 		FA0029C2F4E7DEA2A4782F21 /* Pods_PasswordTextFieldDemoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95C106D8138233173A814CA7 /* Pods_PasswordTextFieldDemoTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -70,7 +69,6 @@
 		07254DA8F238A12B13E91525 /* Pods-PasswordTextFieldTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PasswordTextFieldTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PasswordTextFieldTests/Pods-PasswordTextFieldTests.release.xcconfig"; sourceTree = "<group>"; };
 		243F7B8E60C41CDC52714D62 /* Pods-PasswordTextFieldDemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PasswordTextFieldDemoTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PasswordTextFieldDemoTests/Pods-PasswordTextFieldDemoTests.debug.xcconfig"; sourceTree = "<group>"; };
 		34E05EFDA6B8A6B9ABAB6F3F /* Pods_PasswordTextField.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PasswordTextField.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3EDA518CBC5E3851CAAC25D8 /* Pods-PasswordTextField.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PasswordTextField.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PasswordTextField/Pods-PasswordTextField.debug.xcconfig"; sourceTree = "<group>"; };
 		839CC8291C6B09A400531404 /* StringExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		839CC82D1C6C3CB000531404 /* SecureTextToggleButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecureTextToggleButton.swift; sourceTree = "<group>"; };
 		839CC82F1C6D756300531404 /* CustomStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomStyle.swift; sourceTree = "<group>"; };
@@ -113,7 +111,6 @@
 		B86F74D8E367C39DB0C3D301 /* Pods_PasswordTextFieldTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PasswordTextFieldTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C63B176E407379CBD8B7FBE7 /* Pods-PasswordTextFieldDemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PasswordTextFieldDemoTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-PasswordTextFieldDemoTests/Pods-PasswordTextFieldDemoTests.release.xcconfig"; sourceTree = "<group>"; };
 		CEC8548427014CCFB06FE43A /* Pods_PasswordTextFieldDemoUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PasswordTextFieldDemoUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FB0A465CAF695786CC23DCAC /* Pods-PasswordTextField.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PasswordTextField.release.xcconfig"; path = "Pods/Target Support Files/Pods-PasswordTextField/Pods-PasswordTextField.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -121,7 +118,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				86CBF3239FCBACA3C421DF4A /* Pods_PasswordTextField.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -175,8 +171,6 @@
 		3C88CF8BC9797ED63185077B /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				3EDA518CBC5E3851CAAC25D8 /* Pods-PasswordTextField.debug.xcconfig */,
-				FB0A465CAF695786CC23DCAC /* Pods-PasswordTextField.release.xcconfig */,
 				243F7B8E60C41CDC52714D62 /* Pods-PasswordTextFieldDemoTests.debug.xcconfig */,
 				C63B176E407379CBD8B7FBE7 /* Pods-PasswordTextFieldDemoTests.release.xcconfig */,
 				0095CA209CBEDC480227B9BC /* Pods-PasswordTextFieldDemoUITests.debug.xcconfig */,
@@ -361,12 +355,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 83CBDC391C6B07A5006189C2 /* Build configuration list for PBXNativeTarget "PasswordTextField" */;
 			buildPhases = (
-				66B4D3588EF01B594E66967A /* [CP] Check Pods Manifest.lock */,
 				83CBDC201C6B07A5006189C2 /* Sources */,
 				83CBDC211C6B07A5006189C2 /* Frameworks */,
 				83CBDC221C6B07A5006189C2 /* Headers */,
 				83CBDC231C6B07A5006189C2 /* Resources */,
-				C1FC89B458B56A5D1B8B00DE /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -381,7 +373,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 83CBDC3C1C6B07A5006189C2 /* Build configuration list for PBXNativeTarget "PasswordTextFieldTests" */;
 			buildPhases = (
-				E7DACECA3063EDCDB0241EB6 /* [CP] Check Pods Manifest.lock */,
+				5F4BC36D4A5E5EE50EDD4AF9 /* [CP] Check Pods Manifest.lock */,
 				83CBDC2B1C6B07A5006189C2 /* Sources */,
 				83CBDC2C1C6B07A5006189C2 /* Frameworks */,
 				83CBDC2D1C6B07A5006189C2 /* Resources */,
@@ -619,7 +611,7 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-PasswordTextFieldTests/Pods-PasswordTextFieldTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		66B4D3588EF01B594E66967A /* [CP] Check Pods Manifest.lock */ = {
+		5F4BC36D4A5E5EE50EDD4AF9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -647,21 +639,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-PasswordTextFieldDemoUITests/Pods-PasswordTextFieldDemoUITests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C1FC89B458B56A5D1B8B00DE /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-PasswordTextField/Pods-PasswordTextField-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		C4D5FD521237640950E4F4F8 /* [CP] Check Pods Manifest.lock */ = {
@@ -692,21 +669,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-PasswordTextFieldDemoTests/Pods-PasswordTextFieldDemoTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E7DACECA3063EDCDB0241EB6 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		ED98823D5BAE0DBD8D3C4124 /* [CP] Copy Pods Resources */ = {
@@ -914,7 +876,6 @@
 		};
 		83CBDC3A1C6B07A5006189C2 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3EDA518CBC5E3851CAAC25D8 /* Pods-PasswordTextField.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -935,7 +896,6 @@
 		};
 		83CBDC3B1C6B07A5006189C2 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FB0A465CAF695786CC23DCAC /* Pods-PasswordTextField.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -957,7 +917,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9D2BABDE97871541522A6481 /* Pods-PasswordTextFieldTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = PasswordTextFieldTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -972,7 +931,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 07254DA8F238A12B13E91525 /* Pods-PasswordTextFieldTests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = PasswordTextFieldTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Podfile
+++ b/Podfile
@@ -1,27 +1,19 @@
-# Uncomment the next line to define a global platform for your project
-# platform :ios, '9.0'
+use_frameworks!
 
-target 'PasswordTextField' do
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
-  use_frameworks!
-
-  # Pods for PasswordTextField
-
-  target 'PasswordTextFieldDemoTests' do
+target 'PasswordTextFieldDemoTests' do
     inherit! :search_paths
     # Pods for testing
-  end
-
-  target 'PasswordTextFieldDemoUITests' do
-    inherit! :search_paths
-    # Pods for testing
-  end
-
-  target 'PasswordTextFieldTests' do
-    inherit! :search_paths
-     pod 'Quick', :git => 'https://github.com/Quick/Quick.git' , :branch => 'swift-3.0'
-    pod 'Nimble', :git => 'https://github.com/Quick/Nimble.git', :commit => 'db706fc'
-  end
-
 end
+
+target 'PasswordTextFieldDemoUITests' do
+    inherit! :search_paths
+    # Pods for testing
+end
+
+target 'PasswordTextFieldTests' do
+    inherit! :search_paths
+    pod 'Quick', '~> 0.10.0'
+    pod 'Nimble', '~> 5.1.1'
+end
+
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,31 +1,15 @@
 PODS:
-  - Nimble (5.0.0-alpha.30p1)
-  - Quick (0.9.3)
+  - Nimble (5.1.1)
+  - Quick (0.10.0)
 
 DEPENDENCIES:
-  - Nimble (from `https://github.com/Quick/Nimble.git`, commit `db706fc`)
-  - Quick (from `https://github.com/Quick/Quick.git`, branch `swift-3.0`)
-
-EXTERNAL SOURCES:
-  Nimble:
-    :commit: db706fc
-    :git: https://github.com/Quick/Nimble.git
-  Quick:
-    :branch: swift-3.0
-    :git: https://github.com/Quick/Quick.git
-
-CHECKOUT OPTIONS:
-  Nimble:
-    :commit: db706fc
-    :git: https://github.com/Quick/Nimble.git
-  Quick:
-    :commit: 1503fb019d72417d5d6e4fbebdbaa03c9e4a125f
-    :git: https://github.com/Quick/Quick.git
+  - Nimble (~> 5.1.1)
+  - Quick (~> 0.10.0)
 
 SPEC CHECKSUMS:
-  Nimble: c5b995b4cd57789ec44b0cfb79640fc00e61a8c7
-  Quick: 31fb576b6cbb6b028cc5e0016e4366accbb346f5
+  Nimble: 415e3aa3267e7bc2c96b05fa814ddea7bb686a29
+  Quick: 5d290df1c69d5ee2f0729956dcf0fd9a30447eaa
 
-PODFILE CHECKSUM: 5fcc1934415ce6dd737b259b3870ee8d58ac9d36
+PODFILE CHECKSUM: 761ceea7858cc5c34bbd9e19d2a1658db07ea2bc
 
-COCOAPODS: 1.1.0.rc.2
+COCOAPODS: 1.1.1


### PR DESCRIPTION
* Do not integrate CocoaPods with the target `PasswordTextField`. This is unnecessary as the library itself has no dependencies.
* Update the test dependencies `Quick` and `Nimble` to the latest published versions.

Without this commit, using PasswordTextField in Carthage will fail with the following message, because `PODS_ROOT` is not defined in Carthage.

```
*** Building scheme "PasswordTextField" in PasswordTextField.xcworkspace
** BUILD FAILED **


The following build commands failed:
	PhaseScriptExecution [CP]\ Check\ Pods\ Manifest.lock /Users/kennytm/Library/Developer/Xcode/DerivedData/PasswordTextField-bpvizxblfrzvlofkzgiyvwgfekxy/Build/Intermediates/PasswordTextField.build/Release-iphoneos/PasswordTextField.build/Script-66B4D3588EF01B594E66967A.sh
(1 failure)
error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
A shell task (/usr/bin/xcrun xcodebuild -workspace /path/to/my/project/Carthage/Checkouts/PasswordTextField/PasswordTextField.xcworkspace -scheme PasswordTextField -configuration Release -sdk iphoneos ONLY_ACTIVE_ARCH=NO BITCODE_GENERATION_MODE=bitcode CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean build) failed with exit code 65:
** BUILD FAILED **


The following build commands failed:
	PhaseScriptExecution [CP]\ Check\ Pods\ Manifest.lock /Users/kennytm/Library/Developer/Xcode/DerivedData/PasswordTextField-bpvizxblfrzvlofkzgiyvwgfekxy/Build/Intermediates/PasswordTextField.build/Release-iphoneos/PasswordTextField.build/Script-66B4D3588EF01B594E66967A.sh
(1 failure)
```